### PR TITLE
Relative path instead of file name for convert.awk in Makefile

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -53,10 +53,10 @@ ndata: world2.line
 
 world2.line: world.line legacy_world.line
 	@$(ECHO) "Converting world to world2"
-	$(AWK) -f convert.awk < world.line > world2.line
+	$(AWK) -f ./convert.awk < world.line > world2.line
 	@$(CP) world.linestats world2.linestats
 	@$(ECHO) "Creating legacy world2 database"
-	$(AWK) -f legacy_convert.awk < legacy_world.line > legacy_world2.line
+	$(AWK) -f ./legacy_convert.awk < legacy_world.line > legacy_world2.line
 	@$(CP) legacy_world.linestats legacy_world2.linestats
 	@$(CP) legacy_world.gon legacy_world2.gon
 	@$(CP) legacy_world.gonstats legacy_world2.gonstats

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -50,10 +50,10 @@ ndata: world2.line
 
 world2.line: world.line legacy_world.line
 	@$(ECHO) "Converting world to world2"
-	$(AWK) -f convert.awk < world.line > world2.line
+	$(AWK) -f ./convert.awk < world.line > world2.line
 	@$(CP) world.linestats world2.linestats
 	@$(ECHO) "Creating legacy world2 database"
-	$(AWK) -f legacy_convert.awk < legacy_world.line > legacy_world2.line
+	$(AWK) -f ./legacy_convert.awk < legacy_world.line > legacy_world2.line
 	@$(CP) legacy_world.linestats legacy_world2.linestats
 	@$(CP) legacy_world.gon legacy_world2.gon
 	@$(CP) legacy_world.gonstats legacy_world2.gonstats


### PR DESCRIPTION
Whenever the $AWKPATH variable is set in the .bashrc the two awk files
can not the found and the installation fails with

> install_github("adeckmyn/maps")
> Downloading GitHub repo adeckmyn/maps@master
> from URL https://api.github.com/repos/adeckmyn/maps/zipball/master
> Installing maps
> '/home/X/software/R/R-3.4.0/bin/R' --no-site-file --no-environ --no-save  \
>   --no-restore --quiet CMD INSTALL  \
>   '/tmp/RtmpzCMo6P/devtools7a191fe782b9/adeckmyn-maps-359ba76'  \
>   --library='/home/X/software/R/R-3.4.0/library' --install-tests 
> 
> * installing *source* package ‘maps’ ...
> configure: loading site script /usr/share/site/x86_64-unknown-linux-gnu
> checking for gawk... gawk
> configure: creating ./config.status
> config.status: creating src/Makefile
> ** libs
> ** arch - 
> gcc -std=gnu99 -I/home/X/software/R/R-3.4.0/include -DNDEBUG   -I/usr/local/include   -fpic  -g -O2  -c init.c -o init.o
> gcc -std=gnu99 -I/home/X/software/R/R-3.4.0/include -DNDEBUG   -I/usr/local/include   -fpic  -g -O2  -c mapclip.c -o mapclip.o
> gcc -std=gnu99 -I/home/X/software/R/R-3.4.0/include -DNDEBUG   -I/usr/local/include   -fpic  -g -O2  -c mapget.c -o mapget.o
> gcc -std=gnu99 -I/home/X/software/R/R-3.4.0/include -DNDEBUG   -I/usr/local/include   -fpic  -g -O2  -c smooth.c -o smooth.o
> gcc -std=gnu99 -I/home/X/software/R/R-3.4.0/include -DNDEBUG   -I/usr/local/include   -fpic  -g -O2  -c thin.c -o thin.o
> /home/X/software/R/R-3.4.0/bin/R CMD SHLIB -o maps.so init.o mapclip.o mapget.o smooth.o thin.o 
> make[1]: Entering directory '/tmp/RtmpzCMo6P/devtools7a191fe782b9/adeckmyn-maps-359ba76/src'
> gcc -std=gnu99 -shared -L/usr/local/lib64 -o maps.so init.o mapclip.o mapget.o smooth.o thin.o
> make[1]: Leaving directory '/tmp/RtmpzCMo6P/devtools7a191fe782b9/adeckmyn-maps-359ba76/src'
> gcc -std=gnu99 -g -O2  -I/usr/local/include -L/usr/local/lib64  Gmake.c   -o Gmake
> gcc -std=gnu99 -g -O2  -I/usr/local/include -L/usr/local/lib64  Lmake.c   -o Lmake
> Converting world to world2
> gawk -f convert.awk < world.line > world2.line
> gawk: fatal: can't open source file `convert.awk' for reading (No such file or directory)
> Makefile:55: recipe for target 'world2.line' failed
> make: *** [world2.line] Error 2
> ERROR: compilation failed for package ‘maps’
> * removing ‘/home/X/software/R/R-3.4.0/library/maps’
> Installation failed: Command failed (1)

Using relative paths instead of just the file name the installation works flawlessly.