### PR TITLE
Hingham is in MA not MS

### DIFF
--- a/data-raw/us.cities.tsv
+++ b/data-raw/us.cities.tsv
@@ -404,7 +404,7 @@
 "Highlands Ranch CO"	"CO"	109009	39.55	-104.97	0
 "Hillsboro OR"	"OR"	85046	45.53	-122.94	0
 "Hilo HI"	"HI"	43466	19.7	-155.09	0
-"Hingham MS"	"MS"	41654	42.24	-70.89	0
+"Hingham MA"	"MA"	41654	42.24	-70.89	0
 "Hoboken NJ"	"NJ"	39972	40.74	-74.03	0
 "Hoffman Estates IL"	"IL"	50674	42.06	-88.14	0
 "Hollywood FL"	"FL"	145877	26.03	-80.16	0


### PR DESCRIPTION
Lat/Lon is correct for Hingham MA. I can't find a Hingham in MS.