### PR TITLE
namibia missing a2 fix

### DIFF
--- a/data-raw/makedata-tables.R
+++ b/data-raw/makedata-tables.R
@@ -17,8 +17,8 @@ tsv2rda <-  function(dlist=datalist) {
     infile <- paste0("../data-raw/",dname,".tsv")
     outfile <- paste0("../data/",dname,".rda")
 
-    zz <- read.table(infile, stringsAsFactors=FALSE, 
-                     sep="\t", header=TRUE)
+    zz <- read.table(infile, stringsAsFactors=FALSE,
+                     sep="\t", header=TRUE, na.strings="")
     assign(dname, zz)
     save(list=dname, file=outfile)
   }


### PR DESCRIPTION
The maps::iso3166 alpha 2 country code for Namibia is missing. That is, this call currently returns TRUE:

is.na(maps::iso3166[maps::iso3166$ISOname=="Namibia",]$a2)

# [1] TRUE

The data-raw/iso3166.tsv file currently contains "NA" as the alpha 2 country code for Namibia:

"a2"	"a3"	"ISOname"	"mapname"	"sovereignty"
"NA"	"NAM"	"Namibia"	"Namibia"	"Namibia"

When this tsv is being converted to the package iso3166.rda file it is read with:

read.table(infile, stringsAsFactors=FALSE,
                     sep="\t", header=TRUE)

...with a default parameter: na.strings="NA"

This pull request adds a na.strings="" argument to this call to fix the missing Namibia country code.            